### PR TITLE
Add pre-allocate feature to file storage

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,8 @@ pub enum RustusError {
     UnableToWrite(String),
     #[error("Unable to remove file {0}")]
     UnableToRemove(String),
+    #[error("Unable to resize file {0}")]
+    UnableToResize(String),
     #[error("Unable to prepare info storage. Reason: {0}")]
     UnableToPrepareInfoStorage(String),
     #[error("Unable to prepare storage. Reason: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,6 +39,8 @@ pub enum RustusError {
     UnableToRemove(String),
     #[error("Unable to resize file {0}")]
     UnableToResize(String),
+    #[error("Unable to seek in file {0}")]
+    UnableToSeek(String),
     #[error("Unable to prepare info storage. Reason: {0}")]
     UnableToPrepareInfoStorage(String),
     #[error("Unable to prepare storage. Reason: {0}")]


### PR DESCRIPTION
Added simple pre-allocate functionality, should be enough for simpler cases but needs testing for corner cases.

Also added a couple of tests just for the fun of it.

------
Closes #23 