### PR TITLE
Hooks update.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,11 @@ pub struct NotificationsOptions {
     )]
     pub hooks: Vec<Hook>,
 
+    /// Use this option if you use rustus
+    /// behind any proxy. Like Nginx or Traefik.
+    #[structopt(long, env = "RUSTUS_BEHIND_PROXY")]
+    pub behind_proxy: bool,
+
     /// List of URLS to send webhooks to.
     #[cfg(feature = "http_notifier")]
     #[structopt(long, env = "RUSTUS_HOOKS_HTTP_URLS", use_delimiter = true)]

--- a/src/protocol/core/write_bytes.rs
+++ b/src/protocol/core/write_bytes.rs
@@ -120,11 +120,11 @@ pub async fn write_bytes(
         hook = Hook::PostFinish;
     }
     if state.config.hook_is_active(hook) {
-        let message = state
-            .config
-            .notification_opts
-            .hooks_format
-            .format(&request, &file_info);
+        let message = state.config.notification_opts.hooks_format.format(
+            &request,
+            &file_info,
+            state.config.notification_opts.behind_proxy,
+        );
         let headers = request.headers().clone();
         tokio::task::spawn_local(async move {
             state

--- a/src/protocol/creation/routes.rs
+++ b/src/protocol/creation/routes.rs
@@ -132,11 +132,11 @@ pub async fn create_file(
     }
 
     if state.config.hook_is_active(Hook::PreCreate) {
-        let message = state
-            .config
-            .notification_opts
-            .hooks_format
-            .format(&request, &file_info);
+        let message = state.config.notification_opts.hooks_format.format(
+            &request,
+            &file_info,
+            state.config.notification_opts.behind_proxy,
+        );
         let headers = request.headers();
         state
             .notification_manager
@@ -217,11 +217,11 @@ pub async fn create_file(
     }
 
     if state.config.hook_is_active(post_hook) {
-        let message = state
-            .config
-            .notification_opts
-            .hooks_format
-            .format(&request, &file_info);
+        let message = state.config.notification_opts.hooks_format.format(
+            &request,
+            &file_info,
+            state.config.notification_opts.behind_proxy,
+        );
         let headers = request.headers().clone();
         // Adding send_message task to tokio reactor.
         // Thin function would be executed in background.

--- a/src/protocol/termination/routes.rs
+++ b/src/protocol/termination/routes.rs
@@ -21,11 +21,11 @@ pub async fn terminate(
             return Err(RustusError::FileNotFound);
         }
         if state.config.hook_is_active(Hook::PreTerminate) {
-            let message = state
-                .config
-                .notification_opts
-                .hooks_format
-                .format(&request, &file_info);
+            let message = state.config.notification_opts.hooks_format.format(
+                &request,
+                &file_info,
+                state.config.notification_opts.behind_proxy,
+            );
             let headers = request.headers();
             state
                 .notification_manager
@@ -35,11 +35,11 @@ pub async fn terminate(
         state.info_storage.remove_info(file_id.as_str()).await?;
         state.data_storage.remove_file(&file_info).await?;
         if state.config.hook_is_active(Hook::PostTerminate) {
-            let message = state
-                .config
-                .notification_opts
-                .hooks_format
-                .format(&request, &file_info);
+            let message = state.config.notification_opts.hooks_format.format(
+                &request,
+                &file_info,
+                state.config.notification_opts.behind_proxy,
+            );
             let headers = request.headers().clone();
             tokio::task::spawn_local(async move {
                 state


### PR DESCRIPTION
This is a big update.
At first I updated HTTP hooks, so they
proxy status code and response contents in case of error.

Then I fixed TUSD format it did not match real tusd format.
Also I updated docs and examples for all formats. Related to #90.

And in the end I added `--behind-proxy` parameter to
be able to get real IP's of clients.

Signed-off-by: Pavel Kirilin <win10@list.ru>