### PR TITLE
Updated versions of libs and fixed CMake build error.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
           strip: true
         env:
           JEMALLOC_SYS_WITH_MALLOC_CONF: "background_thread:true,metadata_thp:auto,tcache:false,dirty_decay_ms:30000,muzzy_decay_ms:30000,abort_conf:true"
+          CMAKE_POLICY_VERSION_MINIMUM: "3.10"
       - name: Zip artifcats (based os)
         if: ${{ 'windows-latest' != matrix.platform.runs-on }}
         run: zip -j "rustus-${{ matrix.platform.os-name }}.zip" "target/${{ matrix.platform.target }}/release/rustus"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:1.82-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 
-RUN apt-get update -y && apt-get install -y libjemalloc-dev \
-    build-essential \
-    ca-certificates \
-    cmake \
+RUN apt-get update -y && apt-get install -y libjemalloc-dev=5.3.0-1 \
+    build-essential=12.9 \
+    ca-certificates=20230311 \
+    cmake=3.25.1-1 \
     && apt-get clean -y
 
 WORKDIR /app
@@ -12,12 +12,13 @@ COPY src ./src
 COPY imgs ./imgs
 
 ENV JEMALLOC_SYS_WITH_MALLOC_CONF="background_thread:true,metadata_thp:auto,tcache:false,dirty_decay_ms:30000,muzzy_decay_ms:30000,abort_conf:true"
+ENV CMAKE_POLICY_VERSION_MINIMUM="3.10"
 
 RUN cargo build --release --bin rustus
 
-FROM debian:bookworm-20241111-slim AS base
+FROM debian:bookworm-20250317-slim AS base
 
-RUN apt-get update -y && apt-get install -y ca-certificates \
+RUN apt-get update -y && apt-get install -y ca-certificates=20230311 \
     && apt-get clean -y
 
 COPY --from=builder /app/target/release/rustus /usr/local/bin/


### PR DESCRIPTION
Specifying explicit `CMAKE_POLICY_VERSION_MINIMUM` should be fixed by https://github.com/confluentinc/librdkafka/pull/5012. 